### PR TITLE
AC6: Fix BSS section and update toolchain identification

### DIFF
--- a/board/Corstone-300/Corstone-300.sct
+++ b/board/Corstone-300/Corstone-300.sct
@@ -72,7 +72,7 @@ LR_ITCM ITCM_BASE ITCM_SIZE
     ;-----------------------------------------------------
     ; BSS section - zero-initialized data in DTCM
     ;-----------------------------------------------------
-    ER_BSS +0 UNINIT
+    ER_BSS +0
     {
         *(.bss)
         *(.bss.*)

--- a/src/app_main.c
+++ b/src/app_main.c
@@ -34,12 +34,12 @@ static const osThreadAttr_t executorch_thread_attr = {
 /*-----------------------------------------------------------------------------
   Toolchain identification
  *----------------------------------------------------------------------------*/
-#if defined(__clang__)
+#if defined(__ARMCC_VERSION)
+  #define TOOLCHAIN_NAME "Arm Compiler"
+#elif defined(__clang__)
   #define TOOLCHAIN_NAME "Clang/LLVM"
 #elif defined(__GNUC__)
   #define TOOLCHAIN_NAME "GCC"
-#elif defined(__ARMCC_VERSION)
-  #define TOOLCHAIN_NAME "Arm Compiler"
 #else
   #define TOOLCHAIN_NAME "Unknown"
 #endif


### PR DESCRIPTION
Fix BSS section
  - Some variables used during Ethos-U initialization contained redundant values, which caused the initialization to fail intermittently.

Update toolchain identification
  - AC6 also defines `__clang__`, so the order from CLANG/LLVM must be changed.